### PR TITLE
Added clear all bridges button and corresponding functionality

### DIFF
--- a/tordnscrypt/build.gradle
+++ b/tordnscrypt/build.gradle
@@ -182,4 +182,6 @@ dependencies {
     ksp "com.google.dagger:dagger-compiler:$dagger_version"
     //Persistent Work Manager
     implementation "androidx.work:work-runtime-ktx:$work_version"
+
+    implementation 'androidx.multidex:multidex:2.0.1'
 }

--- a/tordnscrypt/src/main/java/pan/alexander/tordnscrypt/settings/tor_bridges/PreferencesTorBridges.java
+++ b/tordnscrypt/src/main/java/pan/alexander/tordnscrypt/settings/tor_bridges/PreferencesTorBridges.java
@@ -254,6 +254,9 @@ public class PreferencesTorBridges extends Fragment implements View.OnClickListe
         Button btnAddBridges = view.findViewById(R.id.btnAddBridges);
         btnAddBridges.setOnClickListener(this);
 
+        Button btnRemoveAllBridges = view.findViewById(R.id.btnRemoveAllBridges);
+        btnRemoveAllBridges.setOnClickListener(this);
+
         tvBridgesListEmpty = view.findViewById(R.id.tvBridgesListEmpty);
 
         rvBridges = view.findViewById(R.id.rvBridges);
@@ -573,7 +576,9 @@ public class PreferencesTorBridges extends Fragment implements View.OnClickListe
             FileManager.readTextFile(getActivity(), appDataDir + "/app_data/tor/bridges_custom.lst", ADD_BRIDGES_TAG);
         } else if (id == R.id.btnRequestBridges) {
             viewModel.showSelectRequestBridgesTypeDialog();
-        }
+        } else if (id == R.id.btnRemoveAllBridges) {
+        removeAllBridges();
+    }
     }
 
     private void observeDialogsFlow() {
@@ -733,6 +738,32 @@ public class PreferencesTorBridges extends Fragment implements View.OnClickListe
 
     private void sortBridgesByPing() {
         Collections.sort(bridgesToDisplay, new BridgePingComparator());
+    }
+
+    private void removeAllBridges() {
+        final Context context = getActivity();
+        if (context == null) {
+            return;
+        }
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(R.string.confirm_deletion);
+        builder.setMessage(R.string.confirm_remove_all_bridges_message);
+
+        builder.setPositiveButton(getText(R.string.yes), (dialogInterface, i) -> {
+            bridgesInUse.clear();
+            bridgesToDisplay.clear();
+            bridgesInappropriateType.clear();
+
+            FileManager.writeToTextFile(context, bridgesCustomFilePath, new ArrayList<>(), "clear_own_bridges_tag");
+
+            rbNoBridges.performClick();
+
+            Toast.makeText(context, R.string.all_bridges_removed, Toast.LENGTH_SHORT).show();
+        });
+
+        builder.setNegativeButton(getText(R.string.no), (dialog, i) -> dialog.cancel());
+        builder.show();
     }
 
     private void addBridges(final List<String> persistList) {

--- a/tordnscrypt/src/main/res/layout/fragment_preferences_tor_bridges.xml
+++ b/tordnscrypt/src/main/res/layout/fragment_preferences_tor_bridges.xml
@@ -153,18 +153,30 @@
                     app:layout_constraintStart_toEndOf="@+id/btnRequestBridges"
                     app:layout_constraintTop_toBottomOf="@id/cardOwnBridges" />
 
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btnRemoveAllBridges"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="4dp"
+                    android:background="@drawable/button_start_selector"
+                    android:foreground="?attr/selectableItemBackgroundBorderless"
+                    android:text="@string/remove_all_bridges"
+                    android:textColor="@color/buttonTextColor"
+                    app:layout_constraintTop_toBottomOf="@+id/btnAddBridges"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
                 <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/tvBridgesListEmpty"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="8dp"
-                    android:layout_marginTop="8dp"
                     android:layout_marginEnd="8dp"
                     android:textAlignment="center"
                     android:visibility="visible"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/btnAddBridges"
+                    app:layout_constraintTop_toBottomOf="@+id/btnRemoveAllBridges"
                     tools:text="@string/pull_to_refresh" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>

--- a/tordnscrypt/src/main/res/values-ru/strings.xml
+++ b/tordnscrypt/src/main/res/values-ru/strings.xml
@@ -80,6 +80,12 @@
     <string name="pref_fast_use_tor_bridges_own">Использовать свой список мостов</string>
     <string name="pref_fast_use_tor_bridges_request">Запросить мосты</string>
     <string name="pref_fast_use_tor_bridges_add">Добавить мосты</string>
+    <string name="remove_all_bridges">Очистить список мостов</string>
+	<string name="confirm_deletion">Подтверждение удаления</string>
+	<string name="confirm_remove_all_bridges_message">Вы уверены, что хотите удалить все мосты? Это может повлиять на возможность подключения Tor.</string>
+	<string name="yes">Да</string>
+	<string name="no">Нет</string>
+	<string name="all_bridges_removed">Все мосты были удалены</string>
     <string name="pref_fast_use_tor_bridges_edit">Редактировать мост</string>
     <string name="pref_fast_use_tor_bridges_deactivate">Пожалуйста, сначала деактивируйте мост!</string>
     <string name="pref_fast_use_tor_bridges_obfs">Обфускация</string>

--- a/tordnscrypt/src/main/res/values/strings.xml
+++ b/tordnscrypt/src/main/res/values/strings.xml
@@ -125,6 +125,12 @@
     <string name="pref_fast_use_tor_bridges_own">Use Bridges Own List</string>
     <string name="pref_fast_use_tor_bridges_request">Request Bridges</string>
     <string name="pref_fast_use_tor_bridges_add">Add Bridges</string>
+    <string name="remove_all_bridges">Clear bridges list</string>
+    <string name="confirm_deletion">Confirm Deletion</string>
+    <string name="confirm_remove_all_bridges_message">Are you sure you want to remove all bridges? This may affect Tor connection.</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
+    <string name="all_bridges_removed">All bridges removed</string>
     <string name="pref_fast_use_tor_bridges_edit">Edit Bridge</string>
     <string name="pref_fast_use_tor_bridges_deactivate">Pls deactivate bridge first!</string>
     <string name="pref_fast_use_tor_bridges_obfs">Obfuscation</string>


### PR DESCRIPTION
Предыстория: У меня есть парсер который берёт мосты с одного сайта и чекает на работоспособность сохраняя всё в файл. После чего я ручками должен выгружать мосты в прогу. Проблема: если прога показывала что все мосты неработоспособные, то мне ручками приходилось всё удалять. Для этого и была сделана эта кнопка. Делал для себя, но кинул пулл реквест чтобы это было и в офф приложении и мне не приходилось всё время обновлять руками форк для себя.