### PR TITLE
Fix build with newer Go

### DIFF
--- a/tordnscrypt/libs/build
+++ b/tordnscrypt/libs/build
@@ -51,7 +51,7 @@ mkdir arm64-v8a armeabi-v7a
 #################
 
 pushd lyrebird/cmd/lyrebird/
-go build -ldflags="-s -w" -o libobfs4proxy.so
+go build -ldflags="-s -w -checklinkname=0" -o libobfs4proxy.so
 mv libobfs4proxy.so ${LIBS_ROOT}/${ABI}/libobfs4proxy.so || exit 1
 popd
 


### PR DESCRIPTION
Updated the F-Droid recipe to extract the Go version and build it before building the app: https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/pan.alexander.tordnscrypt.stable.yml#L1268

but then it errors out with `link: github.com/wlynxg/anet: invalid reference to net.zoneCache` per https://github.com/wlynxg/anet/blob/main/README.md#how-to-build-with-go-1230-or-later